### PR TITLE
tool_data_table_conf.xml fixes for fasta_indexes and bwa_mem_indexes

### DIFF
--- a/files/galaxy-app/config/tool_data_table_conf.xml
+++ b/files/galaxy-app/config/tool_data_table_conf.xml
@@ -7,7 +7,7 @@
     </table>
     <table name="fasta_indexes" comment_char="#">
         <columns>value, dbkey, name, path</columns>
-        <file path="/cvmfs/data.galaxyproject.org/byhand/location/all_fasta.loc" />
+        <file path="/cvmfs/data.galaxyproject.org/byhand/location/fasta_indexes.loc" />
     </table>
     <!-- Locations of indexes in the BFAST mapper format -->
     <table name="bfast_indexes" comment_char="#">
@@ -41,7 +41,7 @@
     <!-- Locations of indexes in the BWA mapper format -->
     <table name="bwa_mem_indexes" comment_char="#">
         <columns>value, dbkey, name, path</columns>
-        <file path="/cvmfs/data.galaxyproject.org/byhand/location/bwa_index.loc" />
+        <file path="/cvmfs/data.galaxyproject.org/byhand/location/bwa_mem_index.loc" />
     </table>
     <!-- Locations of indexes in the BWA color-space mapper format -->
     <table name="bwa_indexes_color" comment_char="#">


### PR DESCRIPTION
Wrong loc files linked which either caused errors or empty output. With bwa_mem they changed the format of the index files and so the old ones didn't work.  With fasta_indexes the fa.fai files are not in the location specified in all_fasta.loc by design, they are instead in the location in fasta_indexes.loc.